### PR TITLE
Refactor Interface

### DIFF
--- a/mains/tutorials/input_data/Ala_out.top
+++ b/mains/tutorials/input_data/Ala_out.top
@@ -1,0 +1,228 @@
+;
+; File 'topol.top' was generated
+; By user: hartmaec (7122)
+; On host: rh05659.villa-bosch.de
+; At date: Fri Jun 24 15:13:48 2022
+;
+; This is a standalone topology file
+;
+; Created by:
+; :-) GROMACS - gmx pdb2gmx, 2021-MODIFIED (-:
+;
+; Executable: /hits/fast/mbm/hartmaec/sw/gromacs-2021/run/bin/gmx
+; Data prefix: /hits/fast/mbm/hartmaec/sw/gromacs-2021/run
+; Working dir: /hits/fast/mbm/hartmaec/workdir/TopologyChanger/test_delatom
+; Command line:
+; gmx pdb2gmx -f Ala_delHA.gro -o Ala_nat.gro -ignh
+; Force field was read from current directory or a relative path - path added.
+;
+
+; Include forcefield parameters
+#include "./amber99sb-star-ildnp.ff/forcefield.itp"
+
+[ moleculetype ]
+; Name nrexcl
+Protein  3       
+
+[ atoms ]
+; nr type resnr residue atom cgnr charge mass typeB chargeB massB
+; residue 1 ACE rtp ACE q 0.0
+1        CT       1        ACE      CH3      1        -0.3662  12.01   
+2        HC       1        ACE      HH31     2        0.1123   1.008   
+3        HC       1        ACE      HH32     3        0.1123   1.008   
+4        HC       1        ACE      HH33     4        0.1123   1.008   
+5        C        1        ACE      C        5        0.5972   12.01   
+6        O        1        ACE      O        6        -0.5679  16.0     ;        qtot     0       
+; residue 2 ALA rtp ALA q 0.0
+7        N        2        ALA      N        7        -0.4157  14.01   
+8        H        2        ALA      H        8        0.2719   1.008   
+9        CT       2        ALA      CA       9        0.1160   12.01   
+10       CT       2        ALA      CB       10       -0.1825  12.01   
+11       HC       2        ALA      HB1      11       0.0603   1.008   
+12       HC       2        ALA      HB2      12       0.0603   1.008   
+13       HC       2        ALA      HB3      13       0.0603   1.008   
+14       C        2        ALA      C        14       0.5973   12.01   
+15       O        2        ALA      O        15       -0.5679  16.0     ;        qtot     0       
+; residue 3 NME rtp NME q 0.0
+16       N        3        NME      N        16       -0.4157  14.01   
+17       H        3        NME      H        17       0.2719   1.008   
+18       CT       3        NME      CH3      18       -0.149   12.01   
+19       H1       3        NME      HH31     19       0.0976   1.008   
+20       H1       3        NME      HH32     20       0.0976   1.008   
+21       H1       3        NME      HH33     21       0.0976   1.008    ;        qtot     0       
+
+[ bonds ]
+; ai aj funct c0 c1 c2 c3
+1        2        1       
+1        3        1       
+1        4        1       
+1        5        1       
+5        6        1       
+5        7        1       
+7        8        1       
+7        9        1        0.13600  282001.600000  ; patched parameter
+9        10       1        0.14955  259408.000000  ; patched parameter
+9        14       1        0.14916  265265.600000  ; patched parameter
+10       11       1        0.10900  284512.0
+10       12       1        0.10900  284512.0
+10       13       1        0.10900  284512.0
+14       15       1       
+14       16       1       
+16       17       1       
+16       18       1       
+18       19       1       
+18       20       1       
+18       21       1       
+
+[ pairs ]
+; ai aj funct c0 c1 c2 c3
+1        8        1       
+1        9        1       
+2        6        1       
+2        7        1       
+3        6        1       
+3        7        1       
+4        6        1       
+4        7        1       
+5        10       1       
+5        14       1       
+6        8        1       
+6        9        1       
+7        11       1       
+7        12       1       
+7        13       1       
+7        15       1       
+7        16       1       
+8        10       1       
+8        14       1       
+9        17       1       
+9        18       1       
+10       15       1       
+10       16       1       
+11       14       1       
+12       14       1       
+13       14       1       
+14       19       1       
+14       20       1       
+14       21       1       
+15       17       1       
+15       18       1       
+17       19       1       
+17       20       1       
+17       21       1       
+
+[ angles ]
+; ai aj ak funct c0 c1 c2 c3
+2        1        3        1       
+2        1        4        1       
+2        1        5        1       
+3        1        4        1       
+3        1        5        1       
+4        1        5        1       
+1        5        6        1       
+1        5        7        1       
+6        5        7        1       
+5        7        8        1       
+5        7        9        1       
+8        7        9        1       
+7        9        10       1        117.0000000 669.440000  ; patched parameter
+7        9        14       1        117.0000000 527.184000  ; patched parameter
+10       9        14       1        117.0000000 527.184000  ; patched parameter
+9        10       11       1        109.500  418.400 
+9        10       12       1        109.500  418.400 
+9        10       13       1        109.500  418.400 
+11       10       12       1        109.500  292.880 
+11       10       13       1        109.500  292.880 
+12       10       13       1        109.500  292.880 
+9        14       15       1       
+9        14       16       1       
+15       14       16       1       
+14       16       17       1       
+14       16       18       1       
+17       16       18       1       
+16       18       19       1       
+16       18       20       1       
+16       18       21       1       
+19       18       20       1       
+19       18       21       1       
+20       18       21       1       
+
+[ dihedrals ]
+; ai aj ak al funct c0 c1 c2 c3 c4 c5
+2        1        5        6        9       
+2        1        5        7        9       
+3        1        5        6        9       
+3        1        5        7        9       
+4        1        5        6        9       
+4        1        5        7        9       
+1        5        7        8        9       
+1        5        7        9        9       
+6        5        7        8        9       
+6        5        7        9        9       
+5        7        9        10       9       
+5        7        9        14       9        180.000000 1.6279944 1         ; patched parameter
+5        7        9        14       9        180.000000 21.068532 2         ; patched parameter
+5        7        9        14       9        180.000000 1.447664 3         ; patched parameter
+8        7        9        10       9       
+8        7        9        14       9       
+7        9        10       11       9       
+7        9        10       12       9       
+7        9        10       13       9       
+14       9        10       11       9       
+14       9        10       12       9       
+14       9        10       13       9       
+7        9        14       15       9       
+7        9        14       16       9        180.000000 6.556746 1         ; patched parameter
+7        9        14       16       9        180.000000 20.284450 2         ; patched parameter
+7        9        14       16       9        180.000000 0.297901 3         ; patched parameter
+10       9        14       15       9       
+10       9        14       16       9       
+9        14       16       17       9       
+9        14       16       18       9       
+15       14       16       17       9       
+15       14       16       18       9       
+14       16       18       19       9       
+14       16       18       20       9       
+14       16       18       21       9       
+17       16       18       19       9       
+17       16       18       20       9       
+17       16       18       21       9       
+; ai aj ak al funct c0 c1 c2 c3
+1        7        5        6        4       
+5        9        7        8        4       
+7        10       9        14       4        180.0000000 43.93200 2         ; patched parameter
+7        9        14       16       4        105.4    0.75     1       
+9        16       14       15       4       
+14       18       16       17       4       
+
+
+; Include Position restraint file
+#ifdef   POSRES  
+#include "posre.itp"
+#endif  
+
+
+; Include water topology
+#include "./amber99sb-star-ildnp.ff/tip3p.itp"
+
+#ifdef   POSRES_WATER
+[ position_restraints ]
+; Position restraint for each water oxygen
+; i funct fcx fcy fcz
+1        1        1000     1000     1000    
+#endif  
+
+
+; Include topology for ions
+#include "./amber99sb-star-ildnp.ff/ions.itp"
+
+[ system ]
+; Name
+Green    Red      Orange   Magenta  Azure    Cyan     Skyblue  in       water   
+
+[ molecules ]
+; Compound #mols
+Protein  1       
+SOL         551
+NA               2
+CL               2

--- a/mains/tutorials/new_radical_example.py
+++ b/mains/tutorials/new_radical_example.py
@@ -1,0 +1,67 @@
+#%%
+# imports:
+from pathlib import Path
+
+from kimmdy.parsing import read_top
+from kimmdy.topology.topology import Topology
+from grappa_interface import generate_input
+
+from grappa.ff import ForceField
+from grappa.constants import TopologyDict, ParamDict
+from grappa.io import Molecule
+#%%
+top_path = Path(__file__).parents[0] / "input_data" / "Ala_out.top"
+top = Topology(read_top(top_path))
+#%%
+curr_input = generate_input(top)
+#%%    
+at_map = top.ff.atomtypes
+mol = Molecule.create_empty()
+mol.additional_features["is_radical"] = []
+
+for atom in top.atoms.values():
+    mol.atoms.append(int(atom.nr))
+    mol.atomic_nrs.append(int(at_map[atom.type].at_num))
+    mol.partial_charges.append(float(at_map[atom.type].charge))
+    mol.epsilons.append(float(at_map[atom.type].epsilon))
+    mol.sigmas.append(float(at_map[atom.type].sigma))
+    mol.additional_features["is_radical"].append(atom.is_radical)
+
+mol.bonds = [[int(bond.ai),int(bond.aj)] for bond in top.bonds.values()]
+mol.angles = [[int(angle.ai),int(angle.aj),int(angle.ak)] for angle in top.angles.values()]
+mol.propers = [[int(proper.ai),int(proper.aj),int(proper.ak),int(proper.al)] for proper in top.proper_dihedrals.values()]
+mol.impropers = [[int(improper.ai),int(improper.aj),int(improper.ak),int(improper.al)] for improper in top.improper_dihedrals.values()]
+
+# ring membership can be inferred from atom type, I think
+#%%
+mol.to_json('input_data/Ala_in.json')
+#%%
+mol2 = Molecule.from_json('input_data/Ala_in.json')
+
+#%%
+# investigate the output:
+
+print("dict keys and mean values:\n")
+print(*[(k, v.mean()) for (k,v) in zip(params.keys(), params.values())], sep="\n")
+
+print("\n\nsome equililibrium angles:")
+print(params["angle_eq"][:5])
+print("\n\nsome charges:")
+print(params["atom_q"][:5])
+print()
+
+#%%
+# get information on the units by printing the forcefield:
+print(ff)
+# %%
+# load data describing a radical:
+# import json
+# with open('input_data/GrAPPa_input_HAT.json', "r") as f:
+#     data: TopologyDict = json.load(f)
+
+# # initialize the forcefield from a tag:
+# ff = ForceField.from_tag("radical_latest")
+
+# # %%
+# # predict parameters
+# params: ParamDict = ff.params_from_topology_dict(data)

--- a/src/grappa/grappa.py
+++ b/src/grappa/grappa.py
@@ -63,6 +63,7 @@ class Grappa():
         # try if this give good error messages if input is wrong size
         # what happens if no weights are specified?
         parameters = self.model(input)
+        #TODO: convert input to correct format
         return parameters
 
 

--- a/src/grappa/grappa.py
+++ b/src/grappa/grappa.py
@@ -1,0 +1,61 @@
+"""
+Contains the model wrapper class 'Grappa' that is used for parameter prediction.
+"""
+
+from typing import Union
+from pathlib import Path
+
+from grappa.io import Molecule, Parameters
+from grappa.run.run_utils import load_yaml
+from grappa.models.get_models import get_full_model
+
+
+class Grappa():
+    """Model wrapper class
+    """
+    def __init__(self, model) -> None:
+        self.model = model
+
+    @classmethod
+    def from_config(cls, config_path:Union[Path,str]):
+        config = load_yaml(config_path)
+
+        stat_dict = None # is it necessary to give access to this or is it always the default statistics in get_full_model?
+        # could just enforce proper naming in config 
+        model_args = {
+            "statistics": stat_dict,
+            "rep_feats": config["rep_feats"],
+            "between_feats": config["width"],
+            "n_conv": config["n_conv"],
+            "n_att": config["n_att"],
+            "in_feat_name": config["in_feat_name"],
+            "old": config["old_model"],
+            "n_heads": config["n_heads"],
+            "readout_feats": config["readout_width"],
+            "use_improper": config["use_improper"],
+            "dense_layers": config["dense_layers_readout"],
+            "n_att_readout": config["n_att_readout"],
+            "n_heads_readout": config["n_heads_readout"],
+            "reducer_feats": config["reducer_feats"],
+            "attention_hidden_feats": config["attention_hidden_feats"],
+            "positional_encoding": config["positional_encoding"],
+            "layer_norm": config["layer_norm"],
+            "dropout": config["dropout"],
+            "final_dropout": config["final_dropout"],
+            "rep_dropout": config["rep_dropout"],
+            "attentional": config["attentional"],
+            "n_periodicity_proper": config["n_periodicity_proper"],
+            "n_periodicity_improper": config["n_periodicity_improper"],
+        }
+
+        model = get_full_model(**model_args)
+        return Grappa(model)
+
+    def predict(self, input: Molecule) -> Parameters:
+        self.model.eval()
+        # try if this give good error messages if input is wrong size
+        parameters = self.model(input)
+        return parameters
+
+
+

--- a/src/grappa/grappa.py
+++ b/src/grappa/grappa.py
@@ -61,6 +61,7 @@ class Grappa():
     def predict(self, input: Molecule) -> Parameters:
         self.model.eval()
         # try if this give good error messages if input is wrong size
+        # what happens if no weights are specified?
         parameters = self.model(input)
         return parameters
 

--- a/src/grappa/grappa.py
+++ b/src/grappa/grappa.py
@@ -6,7 +6,7 @@ from typing import Union
 from pathlib import Path
 
 from grappa.io import Molecule, Parameters
-from grappa.run.run_utils import load_yaml
+from grappa.run.run_utils import load_yaml, load_weights_torchhub
 from grappa.models.get_models import get_full_model
 
 
@@ -20,35 +20,42 @@ class Grappa():
     def from_config(cls, config_path:Union[Path,str]):
         config = load_yaml(config_path)
 
+        # load model 
+        architecture = config["architecture"]
         stat_dict = None # is it necessary to give access to this or is it always the default statistics in get_full_model?
-        # could just enforce proper naming in config 
+        #TODO: could just enforce proper naming in config 
         model_args = {
             "statistics": stat_dict,
-            "rep_feats": config["rep_feats"],
-            "between_feats": config["width"],
-            "n_conv": config["n_conv"],
-            "n_att": config["n_att"],
-            "in_feat_name": config["in_feat_name"],
-            "old": config["old_model"],
-            "n_heads": config["n_heads"],
-            "readout_feats": config["readout_width"],
-            "use_improper": config["use_improper"],
-            "dense_layers": config["dense_layers_readout"],
-            "n_att_readout": config["n_att_readout"],
-            "n_heads_readout": config["n_heads_readout"],
-            "reducer_feats": config["reducer_feats"],
-            "attention_hidden_feats": config["attention_hidden_feats"],
-            "positional_encoding": config["positional_encoding"],
-            "layer_norm": config["layer_norm"],
-            "dropout": config["dropout"],
-            "final_dropout": config["final_dropout"],
-            "rep_dropout": config["rep_dropout"],
-            "attentional": config["attentional"],
-            "n_periodicity_proper": config["n_periodicity_proper"],
-            "n_periodicity_improper": config["n_periodicity_improper"],
+            "rep_feats": architecture["rep_feats"],
+            "between_feats": architecture["width"],
+            "n_conv": architecture["n_conv"],
+            "n_att": architecture["n_att"],
+            "in_feat_name": architecture["in_feat_name"],
+            "old": architecture["old_model"],
+            "n_heads": architecture["n_heads"],
+            "readout_feats": architecture["readout_width"],
+            "use_improper": architecture["use_improper"],
+            "dense_layers": architecture["dense_layers_readout"],
+            "n_att_readout": architecture["n_att_readout"],
+            "n_heads_readout": architecture["n_heads_readout"],
+            "reducer_feats": architecture["reducer_feats"],
+            "attention_hidden_feats": architecture["attention_hidden_feats"],
+            "positional_encoding": architecture["positional_encoding"],
+            "layer_norm": architecture["layer_norm"],
+            "dropout": architecture["dropout"],
+            "final_dropout": architecture["final_dropout"],
+            "rep_dropout": architecture["rep_dropout"],
+            "attentional": architecture["attentional"],
+            "n_periodicity_proper": architecture["n_periodicity_proper"],
+            "n_periodicity_improper": architecture["n_periodicity_improper"],
         }
-
         model = get_full_model(**model_args)
+
+        #load parameters
+        weights = config["weights"]
+        state_dict = load_weights_torchhub(weights["url"],weights["filename"])
+        model.load_state_dict(state_dict)
+
         return Grappa(model)
 
     def predict(self, input: Molecule) -> Parameters:

--- a/src/grappa/io.py
+++ b/src/grappa/io.py
@@ -1,0 +1,93 @@
+"""
+Contains the grappa input dataclass 'Molecule' and output dataclass 'Parameters'.
+
+XX further describe both
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+import numpy as np
+
+
+# TODO:compare to constants.py TopologyDict -> rename to Topology?
+@dataclass
+class Molecule():
+    """Input dataclass for grappa parameter description
+
+    Angles and proper dihedrals are optional and will be inferred from the bonds if None
+    Additional features are a dict with name: array/list of shape n_atoms x feat_dim
+    """
+    atomnrs: list[int]
+    elements: list[str]
+    partial_charges: list[float]
+    bonds: list[tuple[int,int]]
+    impropers: list[tuple[int,int,int,int]]
+    additional_features: dict[str,list]
+    angles: Optional[list[tuple[int,int,int]]] = None
+    propers: Optional[list[tuple[int,int,int,int]]] = None
+    
+    def _validate(self):
+        # check the input for consistency
+        pass   
+    
+    def  __post_init__(self):
+        if self.angles is None:
+            pass
+            # build angles from bonds
+        if self.propers is None:
+            pass
+            # build dihedrals from bonds
+
+        self._validate()
+    
+# TODO: compare to constants.py ParamDict --> should this stay the same?
+@dataclass
+class Parameters():
+    """
+    A parameter dict containing index tuples (corresponding to the atom_idx passed in the atoms list) and np.ndarrays:
+    
+    {
+    "atom_idxs":np.array, the indices of the atoms in the molecule that correspond to the parameters. In rising order and starts at zero.
+
+    "atom_q":np.array, the partial charges of the atoms.
+
+    "atom_sigma":np.array, the sigma parameters of the atoms.
+
+    "atom_epsilon":np.array, the epsilon parameters of the atoms.
+
+    
+    "{bond/angle}_idxs":np.array of shape (#2/3-body-terms, 2/3), the indices of the atoms in the molecule that correspond to the parameters. The permutation symmetry of the n-body term is already divided out, i.e. this is the minimal set of parameters needed to describe the interaction.
+
+    "{bond/angle}_k":np.array, the force constant of the interaction.
+
+    "{bond/angle}_eq":np.array, the equilibrium distance of the interaction.   
+
+    
+    "{proper/improper}_idxs":np.array of shape (#4-body-terms, 4), the indices of the atoms in the molecule that correspond to the parameters. The central atom is at third position, i.e. index 2. For each entral atom, the array contains all cyclic permutation of the other atoms, i.e. 3 entries that all have different parameters in such a way that the total energy is invariant under cyclic permutation of the atoms.
+
+    "{proper/improper}_ks":np.array of shape (#4-body-terms, n_periodicity), the fourier coefficients for the cos terms of torsion. may be negative instead of the equilibrium dihedral angle (which is always set to zero). n_periodicity is a hyperparemter of the model and defaults to 6.
+
+    "{proper/improper}_ns":np.array of shape (#4-body-terms, n_periodicity), the periodicities of the cos terms of torsion. n_periodicity is a hyperparemter of the model and defaults to 6.
+
+    "{proper/improper}_phases":np.array of shape (#4-body-terms, n_periodicity), the phases of the cos terms of torsion. n_periodicity is a hyperparameter of the model and defaults to 6.
+
+    }
+    """
+    atom_idxs: np.ndarray
+    atom_q: np.ndarray
+    atom_sigma: np.ndarray
+    atom_epsilon: np.ndarray
+    bond_idxs: np.ndarray
+    bond_k: np.ndarray
+    bond_eq: np.ndarray
+    angle_idxs: np.ndarray
+    angle_k: np.ndarray
+    angle_eq: np.ndarray
+    proper_idxs: np.ndarray
+    proper_ks: np.ndarray
+    proper_ns: np.ndarray
+    proper_phases: np.ndarray
+    improper_idxs: np.ndarray
+    improper_ks: np.ndarray
+    improper_ns: np.ndarray
+    improper_phases: np.ndarray

--- a/src/grappa/io.py
+++ b/src/grappa/io.py
@@ -28,15 +28,40 @@ class Molecule():
     
     def _validate(self):
         # check the input for consistency
+        # TODO: compare to current input validation
         pass   
     
     def  __post_init__(self):
-        if self.angles is None:
-            pass
-            # build angles from bonds
-        if self.propers is None:
-            pass
-            # build dihedrals from bonds
+        #TODO: check whether this does what is is supposed to do
+        if self.angles is None or self.propers is None:
+            # generate bound_to dict
+            bound_to = {}
+            for bond in self.bonds:
+                for i,atomnr in enumerate(bond):
+                    if bound_to.get(atomnr):
+                        bound_to[atomnr].append(bond[1-i])
+                        bound_to[atomnr].sort(key=int)
+                    else:
+                        bound_to[atomnr] = [bond[1-i]]
+
+            if self.angles is None:
+                self.angles = []
+                # build angles from bound_to
+                for atomnr, neighbors in bound_to.items():
+                    for i, n1 in enumerate(neighbors):
+                        for ii, n2 in enumerate(neighbors[:i]):
+                            self.angles.append([n1,atomnr,n2])
+
+            if self.propers is None:
+                self.propers = []
+                # build proper dihedrals from bound_to
+                for atomnr, neighbors in bound_to.items():
+                    for i, center in enumerate(neighbors):
+                        for ii, outer1 in enumerate(neighbors[:i]):
+                            for iii,outer2 in enumerate(bound_to.get(center)):
+                                if atomnr != outer2:
+                                    self.propers.append([outer1,atomnr,center,outer2])
+            
 
         self._validate()
     

--- a/src/grappa/io_gromacs.py
+++ b/src/grappa/io_gromacs.py
@@ -1,0 +1,16 @@
+"""
+Classes to generate a Molecule instance from GROMACS input
+"""
+from typing import Union
+from pathlib import Path
+
+from grappa.io import Molecule
+
+class GromacsMolecule(Molecule):
+
+    @classmethod
+    def from_top(cls, top_path:Union[Path,str]):
+        raise NotImplementedError
+    
+    def from_kimmdy(cls, kimmdylist):
+        pass

--- a/src/grappa/io_gromacs.py
+++ b/src/grappa/io_gromacs.py
@@ -11,6 +11,3 @@ class GromacsMolecule(Molecule):
     @classmethod
     def from_top(cls, top_path:Union[Path,str]):
         raise NotImplementedError
-    
-    def from_kimmdy(cls, kimmdylist):
-        pass

--- a/src/grappa/run/run_utils.py
+++ b/src/grappa/run/run_utils.py
@@ -268,7 +268,7 @@ def get_data(ds_paths:List[Union[str, Path]], n_graphs=None, force_factor=0)->Tu
     return datasets, datanames
 
 
-def load_yaml(path:Union[str,Path]):
+def load_yaml(path:Union[str,Path]) -> dict:
     with open(str(path), 'r') as f:
         d = yaml.safe_load(f)
     return d

--- a/src/grappa/run/run_utils.py
+++ b/src/grappa/run/run_utils.py
@@ -3,6 +3,7 @@ import numpy as np
 import random
 import json
 from typing import Tuple, List, Union
+import dataclasses
 import dgl
 import torch
 
@@ -283,6 +284,14 @@ def load_weights_torchhub(url:str, filename:str) -> dict:
     #torch.hub.set_dir('models_path')   # probably not necessary
     state_dict = torch.hub.load_state_dict_from_url(url, model_dir=str(models_path),file_name=filename)
     return state_dict
+
+def dataclass_from_dict(cls, d):
+    try:
+        fieldtypes = {f.name:f.type for f in dataclasses.fields(cls)}
+        return cls(**{f:dataclass_from_dict(fieldtypes[f],d[f]) for f in d})
+    except:
+        return d # Not a dataclass field
+
 
 # def clean_vpath(storage_path, must_contain="log.txt"):
 #     for e in Path(storage_path).glob("*"):

--- a/src/grappa/run/run_utils.py
+++ b/src/grappa/run/run_utils.py
@@ -4,6 +4,7 @@ import random
 import json
 from typing import Tuple, List, Union
 import dgl
+import torch
 
 import yaml
 import math
@@ -277,6 +278,11 @@ def store_yaml(d:dict, path:Union[str,Path]):
     with open(str(path), 'w') as f:
         yaml.dump(d, f)
 
+def load_weights_torchhub(url:str, filename:str) -> dict:
+    models_path = Path(__file__).parents[1] / "mains" / "models"
+    #torch.hub.set_dir('models_path')   # probably not necessary
+    state_dict = torch.hub.load_state_dict_from_url(url, model_dir=str(models_path),file_name=filename)
+    return state_dict
 
 # def clean_vpath(storage_path, must_contain="log.txt"):
 #     for e in Path(storage_path).glob("*"):


### PR DESCRIPTION
## Ideas:
- Separate input generation from prediction
- Make models available outside HITS

## Implementation:
- write an input dataclass 
  - lists of atoms, bonds, angle, proper, improper are attributes
  - a method shall generate angle and proper from bonds (maybe as post init, if angle and proper are empty)
  - additional_features are also an attribute and are a dict with name: array of shape n_atoms x feat_dim
  - has a validate method to check the input
- write a parameterization "grappa" class
  - can be initialized with model
  - has classmethod to initialize from config
    - config contains architecture and location of weigths
      - weigths are stored as state dict and are accessed via torch.hub or local path
  - has a "predict" method that takes an input dataclass instance and returns a output dataclass
    - method has to check whether input and model are compatible because of the variable amount of additional features   